### PR TITLE
Unmarshal recursion

### DIFF
--- a/pkg/river/vm/vm.go
+++ b/pkg/river/vm/vm.go
@@ -90,11 +90,16 @@ func (vm *Evaluator) evaluateBlockOrBody(scope *Scope, assoc map[value.Value]ast
 			rv := reflect.ValueOf(v)
 			if rv.Kind() != reflect.Pointer {
 				panic(fmt.Sprintf("river/vm: expected pointer, got %s", rv.Kind()))
+			} else {
+				return vm.evaluateBlockOrBodyAfterUnmarshal(scope, assoc, node, rv.Elem())
 			}
-			return vm.evaluateBlockOrBody(scope, assoc, node, rv.Elem())
 		})
 	}
 
+	return vm.evaluateBlockOrBodyAfterUnmarshal(scope, assoc, node, rv)
+}
+
+func (vm *Evaluator) evaluateBlockOrBodyAfterUnmarshal(scope *Scope, assoc map[value.Value]ast.Node, node ast.Node, rv reflect.Value) error {
 	// Fully deference rv and allocate pointers as necessary.
 	for rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {

--- a/pkg/river/vm/vm_block_test.go
+++ b/pkg/river/vm/vm_block_test.go
@@ -647,6 +647,8 @@ func BenchmarkWithType(b *testing.B) {
 	var actual OuterBlock
 	for i := 0; i < b.N; i++ {
 		require.NoError(b, eval.Evaluate(nil, &actual))
+		require.True(b, actual.Settings.Called)
+		actual.Settings.Called = false
 	}
 }
 func BenchmarkWithoutType(b *testing.B) {
@@ -669,6 +671,8 @@ func BenchmarkWithoutType(b *testing.B) {
 	var actual OuterBlock
 	for i := 0; i < b.N; i++ {
 		require.NoError(b, eval.Evaluate(nil, &actual))
+		require.True(b, actual.Settings.Called)
+		actual.Settings.Called = false
 	}
 }
 
@@ -790,6 +794,7 @@ type SettingA struct {
 
 func (s *SettingA) UnmarshalRiver(f func(interface{}) error) error {
 	s.Called = true
+	s.FieldA, s.FieldB = "", ""
 	type setting SettingA
 	return f((*setting)(s))
 }
@@ -803,7 +808,8 @@ type SettingB struct {
 
 func (s *SettingB) UnmarshalRiver(f func(interface{}) error) error {
 	s.Called = true
-	return f(&s)
+	s.FieldA, s.FieldB = "", ""
+	return f(s)
 }
 
 func parseBlock(t *testing.T, input string) *ast.BlockStmt {


### PR DESCRIPTION
WIP - how we could avoid unmarshal recursion issue?

Just a sketch - would probably require more thought and testing. The tests pass locally, but it may as well not be fully covered. There is also Decode which I have not read through, which can call the UnmarshalRiver.

Benchmark results:
```
go test -bench="BenchmarkWith" -count=10 -benchmem
goos: darwin
goarch: arm64
pkg: github.com/grafana/agent/pkg/river/vm
BenchmarkWithType-8          1010289          1185 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           988430          1192 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8          1000000          1191 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           992343          1195 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           999805          1194 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           995794          1192 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           989996          1189 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           979698          1191 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           991226          1194 ns/op         632 B/op         13 allocs/op
BenchmarkWithType-8           994666          1192 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8       1000000          1190 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        985818          1191 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        994488          1194 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        996505          1192 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        991407          1192 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        993199          1192 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        997287          1204 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8       1000000          1193 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        991420          1193 ns/op         632 B/op         13 allocs/op
BenchmarkWithoutType-8        995271          1195 ns/op         632 B/op         13 allocs/op
PASS
ok      github.com/grafana/agent/pkg/river/vm   24.982s
```